### PR TITLE
disable further checking once maxClickDistance is reached

### DIFF
--- a/files/advancedcaching/qml/PinchMap.qml
+++ b/files/advancedcaching/qml/PinchMap.qml
@@ -502,7 +502,11 @@ Rectangle {
                 pan(-dx, -dy);
                 __lastX = mouse.x;
                 __lastY = mouse.y;
-                if (Math.pow(mouse.x - __firstX, 2) + Math.pow(mouse.y - __firstY, 2) > maxClickDistance) {
+                /*
+                once the pan threshold is reached, additional checking is unnecessary
+                for the press duration as nothing sets __wasClick back to true
+                */
+                if (__wasClick && Math.pow(mouse.x - __firstX, 2) + Math.pow(mouse.y - __firstY, 2) > maxClickDistance) {
                     __wasClick = false;
                 }
             }


### PR DESCRIPTION
Hi !
When looking through the PinchMap source, I noticed that the click/pan checking is needlessly performed even after the threshold is reached. As the check is being run quite often I made a simple change that disables the check once the threshold is reached. Let me know what you think about it. :)
